### PR TITLE
Foxtrot

### DIFF
--- a/FourthStar1/Controllers/DrillsController.cs
+++ b/FourthStar1/Controllers/DrillsController.cs
@@ -36,8 +36,30 @@ namespace FourthStar1.Controllers
         public async Task<IActionResult> Index()
         {
             var currentuser = await GetCurrentUserAsync();
+
+
+
+            var applicationDBContext = _context.Drills
+                .Include(d => d.Category)
+                ;
+
             return View(await _context.Drills.Where(m => m.UserId == currentuser.Id).ToListAsync());
         }
+
+        //below modeled after IcePhantoms/Bangazon/HomeController
+        //public async Task<IActionResult> Index()
+        //{
+        //    var applicationDbContext = _context.Product
+        //       .Include(p => p.ProductType)
+        //       .Include(p => p.User)
+        //       .OrderBy(p => p.DateCreated)
+        //       .Take(20);
+        //    return View(await applicationDbContext.ToListAsync());
+        //}
+
+
+
+
 
         // GET: Drills/Details/5
         public async Task<IActionResult> Details(int? id)
@@ -47,7 +69,11 @@ namespace FourthStar1.Controllers
                 return NotFound();
             }
 
+            
+
             var drill = await _context.Drills
+                .Include(d => d.Category)
+                .Where(d => d.CategoryId == id)
                 .FirstOrDefaultAsync(m => m.Id == id);
             if (drill == null)
             {
@@ -112,10 +138,20 @@ namespace FourthStar1.Controllers
                 return RedirectToAction(nameof(Index));
             }
 
+            var viewmodel = new DrillCategory()
+            {
+                Drill = null,
+                CategoryOptions = _context.Categories.Select(c => new SelectListItem
+                {
+                    Value = c.CategoryId.ToString(),
+                    Text = c.CategoryName
+                }).ToList()
+            };
 
 
-            //ViewData["CategoryId"] = new SelectList(_context.Categories, "CategoryId", "CategoryName", drill.CategoryId);
-            return View(drill);
+            return View(viewmodel);
+
+
         }
 
         // GET: Drills/Edit/5

--- a/FourthStar1/Controllers/DrillsController.cs
+++ b/FourthStar1/Controllers/DrillsController.cs
@@ -39,11 +39,11 @@ namespace FourthStar1.Controllers
 
 
 
-            var applicationDBContext = _context.Drills
-                .Include(d => d.Category)
-                ;
+            //var applicationDBContext = _context.Drills
+            //    .Include(d => d.Category)
+            //    ;
 
-            return View(await _context.Drills.Where(m => m.UserId == currentuser.Id).ToListAsync());
+            return View(await _context.Drills.Include(d => d.Category).Where(m => m.UserId == currentuser.Id).ToListAsync());
         }
 
         //below modeled after IcePhantoms/Bangazon/HomeController
@@ -73,7 +73,7 @@ namespace FourthStar1.Controllers
 
             var drill = await _context.Drills
                 .Include(d => d.Category)
-                .Where(d => d.CategoryId == id)
+                //.Where(d => d.CategoryId == id)
                 .FirstOrDefaultAsync(m => m.Id == id);
             if (drill == null)
             {

--- a/FourthStar1/Controllers/DrillsController.cs
+++ b/FourthStar1/Controllers/DrillsController.cs
@@ -112,7 +112,9 @@ namespace FourthStar1.Controllers
                 return RedirectToAction(nameof(Index));
             }
 
-            ViewData["CategoryId"] = new SelectList(_context.Categories, "CategoryId", "CategoryName", drill.CategoryId);
+
+
+            //ViewData["CategoryId"] = new SelectList(_context.Categories, "CategoryId", "CategoryName", drill.CategoryId);
             return View(drill);
         }
 
@@ -129,7 +131,18 @@ namespace FourthStar1.Controllers
             {
                 return NotFound();
             }
-            return View(drill);
+
+            var viewmodel = new DrillCategory()
+            {
+                Drill = drill,
+                CategoryOptions = _context.Categories.Select(c => new SelectListItem
+                {
+                    Value = c.CategoryId.ToString(),
+                    Text = c.CategoryName
+                }).ToList()
+            };
+           
+            return View(viewmodel);
         }
 
         // POST: Drills/Edit/5
@@ -137,12 +150,19 @@ namespace FourthStar1.Controllers
         // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Edit(int id, [Bind("Id,DrillName,DrillDescription,PlayersRequired,DateCreated")] Drill drill)
+        public async Task<IActionResult> Edit(int id, [Bind("Id,DrillName,DrillDescription,PlayersRequired,DateCreated,CategoryId")] Drill drill)
         {
             if (id != drill.Id)
             {
                 return NotFound();
             }
+
+            //don't fully understand why removing user/userId from ModelState here.
+            ModelState.Remove("User");
+            ModelState.Remove("userId");
+
+            var user = await GetCurrentUserAsync();
+            drill.UserId = user.Id;
 
             if (ModelState.IsValid)
             {
@@ -164,7 +184,20 @@ namespace FourthStar1.Controllers
                 }
                 return RedirectToAction(nameof(Index));
             }
-            return View(drill);
+
+            /*else do the work similar to create/ 'post' however drill is already defined, Drill = drill*/
+            var viewmodel = new DrillCategory()
+            {
+                Drill = drill,
+                CategoryOptions = _context.Categories.Select(c => new SelectListItem
+                {
+                    Value = c.CategoryId.ToString(),
+                    Text = c.CategoryName
+                }).ToList()
+            };
+
+
+            return View(viewmodel);
         }
 
         // GET: Drills/Delete/5

--- a/FourthStar1/Models/Category.cs
+++ b/FourthStar1/Models/Category.cs
@@ -7,6 +7,7 @@ namespace FourthStar1.Models
 {
     public class Category
     {
+        
         public int CategoryId { get; set; }
         public string CategoryName { get; set; }
     }

--- a/FourthStar1/Models/Drill.cs
+++ b/FourthStar1/Models/Drill.cs
@@ -26,8 +26,10 @@ namespace FourthStar1.Models
             [ForeignKey("ApplicationUser")]
             public string UserId { get; set; }
 
-            [ForeignKey("Category Id")]
+            [ForeignKey("CategoryId")]
             public int CategoryId { get; set; }
+
+            public Category Category { get; set; }
 
             [Display(Name = "Date Created")]
             public DateTime DateCreated { get; set; }

--- a/FourthStar1/Views/Drills/Create.cshtml
+++ b/FourthStar1/Views/Drills/Create.cshtml
@@ -28,7 +28,7 @@
                 <span asp-validation-for="Drill.PlayersRequired" class="text-danger"></span>
             </div>
 
-            @*using the below modeled after studentexercisesEF from C29 repo, i want a dropdown option to categorize drills*@
+            @* the below is modeled after studentexercisesEF from C29 repo, i want a dropdown option to categorize drills*@
             @*<div class=“form-group”>
                 
                 <label asp-for=“CategoryOptions” class=“control-label”></label>

--- a/FourthStar1/Views/Drills/Details.cshtml
+++ b/FourthStar1/Views/Drills/Details.cshtml
@@ -10,28 +10,34 @@
     <h4>Drill</h4>
     <hr />
     <dl class="row">
-        <dt class = "col-sm-2">
+        <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.DrillName)
         </dt>
-        <dd class = "col-sm-10">
+        <dd class="col-sm-10">
             @Html.DisplayFor(model => model.DrillName)
         </dd>
-        <dt class = "col-sm-2">
+        <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.DrillDescription)
         </dt>
-        <dd class = "col-sm-10">
+        <dd class="col-sm-10">
             @Html.DisplayFor(model => model.DrillDescription)
         </dd>
-        <dt class = "col-sm-2">
+        <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.PlayersRequired)
         </dt>
-        <dd class = "col-sm-10">
+        <dd class="col-sm-10">
             @Html.DisplayFor(model => model.PlayersRequired)
         </dd>
-        <dt class = "col-sm-2">
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.Category.CategoryName)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.Category.CategoryName)
+        </dd>
+        <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.DateCreated)
         </dt>
-        <dd class = "col-sm-10">
+        <dd class="col-sm-10">
             @Html.DisplayFor(model => model.DateCreated)
         </dd>
     </dl>

--- a/FourthStar1/Views/Drills/Index.cshtml
+++ b/FourthStar1/Views/Drills/Index.cshtml
@@ -19,9 +19,12 @@
                 @Html.DisplayNameFor(model => model.DrillDescription)
             </th>
             <th>
+                @Html.DisplayNameFor(model => model.Category)
+            </th>
+            <th>
                 @Html.DisplayNameFor(model => model.PlayersRequired)
             </th>
-            
+
             <th></th>
         </tr>
     </thead>
@@ -35,9 +38,12 @@
                 @Html.DisplayFor(modelItem => item.DrillDescription)
             </td>
             <td>
+                @Html.DisplayFor(modelItem => item.Category.CategoryName)
+            </td>
+            <td>
                 @Html.DisplayFor(modelItem => item.PlayersRequired)
             </td>
-            
+
             <td>
                 <a asp-action="Edit" asp-route-id="@item.Id">Edit</a> |
                 <a asp-action="Details" asp-route-id="@item.Id">Details</a> |

--- a/FourthStar1/Views/Drills/Index.cshtml
+++ b/FourthStar1/Views/Drills/Index.cshtml
@@ -19,7 +19,7 @@
                 @Html.DisplayNameFor(model => model.DrillDescription)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Category)
+                @Html.DisplayNameFor(model => model.Category.CategoryName)
             </th>
             <th>
                 @Html.DisplayNameFor(model => model.PlayersRequired)


### PR DESCRIPTION
# Description

Improved User Experience!  User now is able to see "Category Name" listed on their drills, as opposed to "CategoryId" on both the Drills/Index and Drills/Details views 

accomplished via  ``` .Include(d =>d.category ) ``` statement on drillscontroller.cs which joins data between "drills" and "categories" tables



## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions for Change Made
Log in, click "Drills" on navbar

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added test instructions that prove my fix is effective or that my feature works
